### PR TITLE
Forbedrer SEO med strukturerte data, Open Graph og sitemap

### DIFF
--- a/gjestebok.html
+++ b/gjestebok.html
@@ -5,9 +5,17 @@
   <title>Gjestebok — Joakim Lindquister</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Si hei, etterlat en tanke, eller bare en emoji." />
+  <link rel="canonical" href="https://quist.github.io/gjestebok.html" />
   <meta property="og:title" content="Gjestebok — Joakim Lindquister" />
   <meta property="og:description" content="Si hei, etterlat en tanke, eller bare en emoji." />
   <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://quist.github.io/gjestebok.html" />
+  <meta property="og:image" content="https://quist.github.io/profile.jpg" />
+  <meta property="og:locale" content="nb_NO" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Gjestebok — Joakim Lindquister" />
+  <meta name="twitter:description" content="Si hei, etterlat en tanke, eller bare en emoji." />
+  <meta name="twitter:image" content="https://quist.github.io/profile.jpg" />
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='oklch(0.965 0.018 85)'/><text x='50' y='58' text-anchor='middle' font-family='Georgia,serif' font-style='italic' font-size='38' fill='oklch(0.50 0.13 35)'>JL</text></svg>" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/index.html
+++ b/index.html
@@ -2,17 +2,41 @@
 <html lang="nb">
 <head>
   <meta charset="UTF-8" />
-  <title>Joakim Lindquister</title>
+  <title>Joakim Lindquister — full-stack utvikler i Bekk</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Joakim Lindquister — full-stack utvikler i Bekk. Bygger systemer som betyr noe for folk." />
-  <meta property="og:title" content="Joakim Lindquister" />
+  <link rel="canonical" href="https://quist.github.io/" />
+  <meta property="og:title" content="Joakim Lindquister — full-stack utvikler i Bekk" />
   <meta property="og:description" content="Full-stack utvikler i Bekk. Bygger systemer som betyr noe for folk." />
   <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://quist.github.io/" />
+  <meta property="og:image" content="https://quist.github.io/profile.jpg" />
+  <meta property="og:locale" content="nb_NO" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Joakim Lindquister — full-stack utvikler i Bekk" />
+  <meta name="twitter:description" content="Full-stack utvikler i Bekk. Bygger systemer som betyr noe for folk." />
+  <meta name="twitter:image" content="https://quist.github.io/profile.jpg" />
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='oklch(0.965 0.018 85)'/><text x='50' y='58' text-anchor='middle' font-family='Georgia,serif' font-style='italic' font-size='38' fill='oklch(0.50 0.13 35)'>JL</text></svg>" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500;600&family=Instrument+Serif:ital@0;1&family=Caveat:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Joakim Lindquister",
+    "url": "https://quist.github.io/",
+    "image": "https://quist.github.io/profile.jpg",
+    "jobTitle": "Full-stack utvikler",
+    "worksFor": { "@type": "Organization", "name": "Bekk" },
+    "email": "joakiml@gmail.com",
+    "sameAs": [
+      "https://github.com/quist",
+      "https://no.linkedin.com/in/joakim-lindquister-8a037865"
+    ]
+  }
+  </script>
 </head>
 <body>
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://quist.github.io/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://quist.github.io/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://quist.github.io/gjestebok.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Hva er gjort

- **Tittel forbedret** — `<title>` på forsiden inkluderer nå yrkestittel og arbeidsgiver for bedre søkeranking
- **Canonical-lenker** — Lagt til på begge sider for å unngå duplikatinnhold
- **Open Graph** — `og:url`, `og:image` og `og:locale` på begge sider, slik at delinger på LinkedIn/Slack får riktig forhåndsvisning med profilbilde
- **Twitter Cards** — `twitter:card`, `twitter:title`, `twitter:description` og `twitter:image` på begge sider
- **JSON-LD Person-schema** — Strukturerte data på forsiden slik at Google forstår hvem Joakim er, hvilken jobb han har og kontaktinformasjon
- **`robots.txt`** — Oppretter eksplisitt tillatelse for søkemotorer og peker til sitemap
- **`sitemap.xml`** — Hjelper Google crawle begge sider med riktig prioritet

## Test

- Valider JSON-LD med [Google Rich Results Test](https://search.google.com/test/rich-results)
- Valider Open Graph med [og.tools](https://og.tools) eller LinkedIn post inspector

https://claude.ai/code/session_015fUkvsAcUuKpFFdLKcHjX9

---
_Generated by [Claude Code](https://claude.ai/code/session_015fUkvsAcUuKpFFdLKcHjX9)_